### PR TITLE
[New feature] Fix display of help

### DIFF
--- a/fonctions.c
+++ b/fonctions.c
@@ -1,0 +1,25 @@
+#include "fonctions.h"
+
+#define MAX_PASSWORD_LENGTH 10
+#define MAX_CHARSET_LENGTH 100
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <zip.h>
+
+/** 
+ * Afficher l'aide
+ */
+void print_help() {
+    printf("Usage: ./zip [OPTION]... [FILE]...\n");
+    printf("Options:\n");
+    printf(" -h, --help                    Show this help\n");
+    printf(" -o, --open                    Open a zip file for browsing\n");
+    printf(" -b, --bruteforce              Try to bruteforce the password\n");
+    printf(" -d, --dictionary=FILE         Try to bruteforce the password with a dictionary\n");
+    printf(" -p, --password=PASSWORD       Use this password\n");
+    printf(" -e, --extract=FILE            Extract this file\n");
+    printf(" -i, --include=FILE            Include this file\n");
+}


### PR DESCRIPTION
### Proposed changes
When the `print_help()` function is called, the displayed help is incorrect. The display needs to be corrected to match the available options. This will ensure that users get accurate information about how to use the program.

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature
- [] Documentation Update

### Further comments
This is a minor modification that focuses solely on correcting the display of the help. No other functionality is affected by this change. The goal is to enhance the user experience by providing clear and accurate instructions.
